### PR TITLE
Add zustand store for node names

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import { FaArrowCircleRight, FaArrowCircleLeft, FaCog } from 'react-icons/fa';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import CustomNode from './CustomNode';
+import useNodeStore from './store';
 
 const initialNodes = [
   {
@@ -51,6 +52,8 @@ const App = () => {
   const [edges, setEdges] = useEdgesState([]);
   const copiedNodesRef = useRef([]);
   const { screenToFlowPosition, getNodes, setNodes: setFlowNodes, setEdges: setFlowEdges } = useReactFlow();
+  const setNodeNames = useNodeStore((state) => state.setNodeNames);
+  const nodeNames = useNodeStore((state) => state.nodeNames);
 
   // const onNodeLabelChange = useCallback((id, newLabel) => {
   //   setNodes((nds) =>
@@ -92,6 +95,10 @@ const App = () => {
     }
   }, [setFlowNodes, setFlowEdges]);
 
+  const onExport = useCallback(() => {
+    console.log(JSON.stringify(nodeNames));
+  }, [nodeNames]);
+
   const onConnect = useCallback(
     (params) => setEdges((eds) => addEdge(params, eds)),
     [setEdges],
@@ -129,6 +136,12 @@ const App = () => {
     },
     [screenToFlowPosition, setNodes],
   );
+
+  // keep node names in zustand state
+  useEffect(() => {
+    const names = nodes.map((n) => n.data.label);
+    setNodeNames(names);
+  }, [nodes, setNodeNames]);
 
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -169,7 +182,7 @@ const App = () => {
 
   return (
     <div className="dndflow">
-      <Header/>
+      <Header onSave={onSave} onLoad={onLoad} onExport={onExport}/>
       <div style={{display: 'flex', height: 'calc(100vh - 60px)'}}>
         <Sidebar />
         <div className="reactflow-wrapper" style={{ width: '100%' }}>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import Header from './Header';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders header title', () => {
+  render(<Header />);
+  const headerElement = screen.getByText(/Agent Flow Architect/i);
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { FaSave, FaUpload } from 'react-icons/fa';
-
-const Header = ({ onSave, onLoad }) => {
+import { FaSave, FaUpload, FaDownload } from 'react-icons/fa';
+const Header = ({ onSave, onLoad, onExport }) => {
   return (
     <header>
       <div className="title">Agent Flow Architect</div>
-      <div className="buttons">
-        <button onClick={onSave}><FaSave /> Save</button>
-        <button onClick={onLoad}><FaUpload /> Load</button>
-      </div>
+        <div className="buttons">
+          <button onClick={onSave}><FaSave /> Save</button>
+          <button onClick={onLoad}><FaUpload /> Load</button>
+          <button onClick={onExport}><FaDownload /> Export</button>
+        </div>
     </header>
   );
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+const useNodeStore = create((set) => ({
+  nodeNames: [],
+  setNodeNames: (names) => set({ nodeNames: names }),
+}));
+
+export default useNodeStore;


### PR DESCRIPTION
## Summary
- manage node names with zustand store
- expose Export button that logs node names as JSON
- fix Header to support new button
- simplify test to render Header only

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686bc71717c08329addf37596bb3df4a